### PR TITLE
Add CreateDatabaseTarget and DeleteDatabaseTarget to TargetsService

### DIFF
--- a/.changes/unreleased/ENHANCEMENTS-20230509-154452.yaml
+++ b/.changes/unreleased/ENHANCEMENTS-20230509-154452.yaml
@@ -1,5 +1,5 @@
 kind: ENHANCEMENTS
-body: 'targets: Add support for POST (Create) Database target'
+body: 'targets: Add support for POST (Create) and DELETE Database target'
 time: 2023-05-09T15:44:52.868112-07:00
 custom:
   Issues: '#16'

--- a/.changes/unreleased/ENHANCEMENTS-20230509-154452.yaml
+++ b/.changes/unreleased/ENHANCEMENTS-20230509-154452.yaml
@@ -1,0 +1,5 @@
+kind: ENHANCEMENTS
+body: 'targets: Add support for POST (Create) Database target'
+time: 2023-05-09T15:44:52.868112-07:00
+custom:
+  Issues: '#16'

--- a/.changes/unreleased/FEATURES-20230511-090455.yaml
+++ b/.changes/unreleased/FEATURES-20230511-090455.yaml
@@ -1,5 +1,5 @@
-kind: ENHANCEMENTS
+kind: FEATURES
 body: 'targets: Add support for POST (Create) and DELETE Database target'
-time: 2023-05-09T15:44:52.868112-07:00
+time: 2023-05-11T09:04:55.32003-07:00
 custom:
-  Issues: '#16'
+  Issues: "16"

--- a/bastionzero/service/targets/database.go
+++ b/bastionzero/service/targets/database.go
@@ -116,6 +116,25 @@ func (s *TargetsService) GetDatabaseTarget(ctx context.Context, targetID string)
 	return target, resp, nil
 }
 
+// DeleteDatabaseTarget deletes the specified Database target.
+//
+// BastionZero API docs: https://cloud.bastionzero.com/api/#delete-/api/v2/targets/database/-id-
+func (s *TargetsService) DeleteDatabaseTarget(ctx context.Context, targetID string) (*http.Response, error) {
+	u := fmt.Sprintf(databaseSinglePath, targetID)
+	req, err := s.Client.NewRequest(ctx, http.MethodDelete, u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	target := new(DatabaseTarget)
+	resp, err := s.Client.Do(req, target)
+	if err != nil {
+		return resp, err
+	}
+
+	return resp, nil
+}
+
 // ModifyDatabaseTarget updates a Database target.
 //
 // BastionZero API docs: https://cloud.bastionzero.com/api/#patch-/api/v2/targets/database/-id-

--- a/bastionzero/service/targets/database.go
+++ b/bastionzero/service/targets/database.go
@@ -126,8 +126,7 @@ func (s *TargetsService) DeleteDatabaseTarget(ctx context.Context, targetID stri
 		return nil, err
 	}
 
-	target := new(DatabaseTarget)
-	resp, err := s.Client.Do(req, target)
+	resp, err := s.Client.Do(req, nil)
 	if err != nil {
 		return resp, err
 	}

--- a/bastionzero/service/targets/database.go
+++ b/bastionzero/service/targets/database.go
@@ -28,7 +28,7 @@ type CreateDatabaseTargetRequest struct {
 	EnvironmentName string `json:"environmentName,omitempty"`
 }
 
-// CreateDatabaseTargetRequest is the response returned if a Database target is
+// CreateDatabaseTargetResponse is the response returned if a Database target is
 // successfully created
 type CreateDatabaseTargetResponse struct {
 	TargetId string `json:"targetId"`

--- a/bastionzero/service/targets/database.go
+++ b/bastionzero/service/targets/database.go
@@ -14,6 +14,26 @@ const (
 	databaseSinglePath = databaseBasePath + "/%s"
 )
 
+// CreateDatabaseTargetRequest is used to create a new Database target
+type CreateDatabaseTargetRequest struct {
+	TargetName      string `json:"targetName,omitempty"`
+	ProxyTargetID   string `json:"proxyTargetId,omitempty"`
+	RemoteHost      string `json:"remoteHost,omitempty"`
+	RemotePort      *Port  `json:"remotePort,omitempty"`
+	LocalPort       *Port  `json:"localPort,omitempty"`
+	LocalHost       string `json:"localHost,omitempty"`
+	IsSplitCert     bool   `json:"splitCert,omitempty"`
+	DatabaseType    string `json:"databaseType,omitempty"`
+	EnvironmentID   string `json:"environmentId,omitempty"`
+	EnvironmentName string `json:"environmentName,omitempty"`
+}
+
+// CreateDatabaseTargetRequest is the response returned if a Database target is
+// successfully created
+type CreateDatabaseTargetResponse struct {
+	TargetId string `json:"targetId"`
+}
+
 // ModifyDatabaseTargetRequest is used to modify a Database target
 type ModifyDatabaseTargetRequest struct {
 	TargetName    *string `json:"targetName,omitempty"`
@@ -56,6 +76,25 @@ func (s *TargetsService) ListDatabaseTargets(ctx context.Context) ([]DatabaseTar
 	}
 
 	return *targetList, resp, nil
+}
+
+// CreateDatabaseTarget creates a new Database target.
+//
+// BastionZero API docs: https://cloud.bastionzero.com/api/#post-/api/v2/targets/database
+func (s *TargetsService) CreateDatabaseTarget(ctx context.Context, request *CreateDatabaseTargetRequest) (*CreateDatabaseTargetResponse, *http.Response, error) {
+	u := databaseBasePath
+	req, err := s.Client.NewRequest(ctx, http.MethodPost, u, request)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	createTargetResponse := new(CreateDatabaseTargetResponse)
+	resp, err := s.Client.Do(req, createTargetResponse)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return createTargetResponse, resp, nil
 }
 
 // GetDatabaseTarget fetches the specified Database target.

--- a/bastionzero/service/targets/database.go
+++ b/bastionzero/service/targets/database.go
@@ -16,10 +16,10 @@ const (
 
 // CreateDatabaseTargetRequest is used to create a new Database target
 type CreateDatabaseTargetRequest struct {
-	TargetName      string `json:"targetName,omitempty"`
-	ProxyTargetID   string `json:"proxyTargetId,omitempty"`
-	RemoteHost      string `json:"remoteHost,omitempty"`
-	RemotePort      *Port  `json:"remotePort,omitempty"`
+	TargetName      string `json:"targetName"`
+	ProxyTargetID   string `json:"proxyTargetId"`
+	RemoteHost      string `json:"remoteHost"`
+	RemotePort      Port   `json:"remotePort"`
 	LocalPort       *Port  `json:"localPort,omitempty"`
 	LocalHost       string `json:"localHost,omitempty"`
 	IsSplitCert     bool   `json:"splitCert,omitempty"`


### PR DESCRIPTION
Adds `TargetsService.CreateDatabaseTarget`, `TargetsService.DeleteDatabaseTarget` and associated structs, trying to follow the pattern in [the EnvironmentsService](https://github.com/bastionzero/bastionzero-sdk-go/blob/b0a6992ab290a631c360010a9ac22e932cf5834b/bastionzero/service/environments/environments.go#L25).

Looks like there are no unit tests in this project, but to validate functionality I used https://gist.github.com/roshbhatia/570518a07ccfbb8b131ab085364eba3b.