### PR TITLE
Add SQL Server and RDP support

### DIFF
--- a/.changes/unreleased/FEATURES-20230614-130429.yaml
+++ b/.changes/unreleased/FEATURES-20230614-130429.yaml
@@ -1,0 +1,5 @@
+kind: FEATURES
+body: 'connections/rdp-sqlserver: Add support for RDP and SQL Server connections'
+time: 2023-06-14T13:04:29.754752-04:00
+custom:
+  Issues: "23"

--- a/bastionzero/bastionzero.go
+++ b/bastionzero/bastionzero.go
@@ -32,7 +32,7 @@ import (
 )
 
 const (
-	libraryVersion = "v0.3.0"
+	libraryVersion = "v0.4.0"
 	// DefaultBaseURL is the default BastionZero API URL the Client communicates
 	// with
 	DefaultBaseURL   = "https://cloud.bastionzero.com/"

--- a/bastionzero/bastionzero.go
+++ b/bastionzero/bastionzero.go
@@ -32,7 +32,7 @@ import (
 )
 
 const (
-	libraryVersion = "v0.4.0"
+	libraryVersion = "v0.3.0"
 	// DefaultBaseURL is the default BastionZero API URL the Client communicates
 	// with
 	DefaultBaseURL   = "https://cloud.bastionzero.com/"

--- a/bastionzero/service/connections/connections.go
+++ b/bastionzero/service/connections/connections.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/bastionzero/bastionzero-sdk-go/bastionzero/service/connections/connectionstate"
+	"github.com/bastionzero/bastionzero-sdk-go/bastionzero/service/policies/verbtype"
 	"github.com/bastionzero/bastionzero-sdk-go/bastionzero/types"
 	"github.com/bastionzero/bastionzero-sdk-go/bastionzero/types/targettype"
 	"github.com/bastionzero/bastionzero-sdk-go/internal/client"
@@ -93,6 +94,7 @@ type CreateUniversalConnectionRequest struct {
 	EnvironmentName string                `json:"envName,omitempty"`
 	TargetGroups    []string              `json:"targetGroups,omitempty"`
 	TargetType      targettype.TargetType `json:"targetType,omitempty"`
+	VerbType        verbtype.VerbType     `json:"verbType,omitempty"`
 }
 
 // CreateUniversalSshConnectionRequest is used to create a connection to any
@@ -114,6 +116,7 @@ type CreateUniversalConnectionResponse struct {
 	TargetName            string                `json:"targetName"`
 	TargetUser            string                `json:"targetUser"`
 	TargetType            targettype.TargetType `json:"targetType"`
+	VerbType              verbtype.VerbType     `json:"verbType"`
 	AgentPublicKey        string                `json:"agentPublicKey"`
 	AgentVersion          string                `json:"agentVersion"`
 	ConnectionAuthDetails ConnectionAuthDetails `json:"connectionAuthDetails"`

--- a/bastionzero/service/connections/rdp.go
+++ b/bastionzero/service/connections/rdp.go
@@ -1,0 +1,52 @@
+package connections
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/bastionzero/bastionzero-sdk-go/internal/client"
+)
+
+const (
+	rdpBasePath   = connectionsBasePath + "/rdp"
+	rdpSinglePath = rdpBasePath + "/%s"
+)
+
+// RDPConnection is a connection to an RDP target
+type RDPConnection struct {
+	Connection
+
+	RemoteHost string `json:"remoteHost"`
+	RemotePort int    `json:"remotePort"`
+	TargetName string `json:"targetName"`
+}
+
+// ListRDPConnections lists all RDP connections.
+//
+// BastionZero API docs: https://cloud.bastionzero.com/api/#get-/api/v2/connections/rdp
+func (s *ConnectionsService) ListRDPConnections(ctx context.Context, opts *ListConnectionOptions) ([]RDPConnection, *http.Response, error) {
+	u := rdpBasePath
+	u, err := client.AddOptions(u, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	connList := new([]RDPConnection)
+	resp, err := s.Client.Do(req, connList)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return *connList, resp, nil
+}
+
+// Ensure RDPConnection implementation satisfies the expected interfaces.
+var (
+	// RDPConnection implements ConnectionInterface
+	_ ConnectionInterface = &RDPConnection{}
+)

--- a/bastionzero/service/connections/sqlserver.go
+++ b/bastionzero/service/connections/sqlserver.go
@@ -1,0 +1,52 @@
+package connections
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/bastionzero/bastionzero-sdk-go/internal/client"
+)
+
+const (
+	sqlServerBasePath   = connectionsBasePath + "/sqlserver"
+	sqlServerSinglePath = sqlServerBasePath + "/%s"
+)
+
+// SQLServerConnection is a connection to an SQL Server
+type SQLServerConnection struct {
+	Connection
+
+	RemoteHost string `json:"remoteHost"`
+	RemotePort int    `json:"remotePort"`
+	TargetName string `json:"targetName"`
+}
+
+// ListSQLServerConnections lists all SQL Server connections.
+//
+// BastionZero API docs: https://cloud.bastionzero.com/api/#get-/api/v2/connections/sqlserver
+func (s *ConnectionsService) ListSQLServerConnections(ctx context.Context, opts *ListConnectionOptions) ([]SQLServerConnection, *http.Response, error) {
+	u := sqlServerBasePath
+	u, err := client.AddOptions(u, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	connList := new([]SQLServerConnection)
+	resp, err := s.Client.Do(req, connList)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return *connList, resp, nil
+}
+
+// Ensure SQLServerConnection implementation satisfies the expected interfaces.
+var (
+	// SQLServerConnection implements ConnectionInterface
+	_ ConnectionInterface = &SQLServerConnection{}
+)

--- a/bastionzero/service/policies/verbtype/generated.go
+++ b/bastionzero/service/policies/verbtype/generated.go
@@ -6,6 +6,8 @@ var validVerbTypeValues = map[VerbType]struct{}{
 	Shell:        {},
 	FileTransfer: {},
 	Tunnel:       {},
+	RDP:          {},
+	SQLServer:    {},
 }
 
 // Valid validates if a value is a valid VerbType
@@ -20,5 +22,7 @@ func VerbTypeValues() []VerbType {
 		Shell,
 		FileTransfer,
 		Tunnel,
+		RDP,
+		SQLServer,
 	}
 }

--- a/bastionzero/service/policies/verbtype/verbtype.go
+++ b/bastionzero/service/policies/verbtype/verbtype.go
@@ -12,4 +12,8 @@ const (
 	FileTransfer VerbType = "FileTransfer"
 	// Tunnel represents the ability to make an SSH tunnel
 	Tunnel VerbType = "Tunnel"
+	// RDP represents the ability to connect using the Remote Desktop Protocol
+	RDP VerbType = "RDP"
+	// SQLServer represents the ability to connect to a Windows SQL Server
+	SQLServer VerbType = "SQLServer"
 )


### PR DESCRIPTION
+ Add endpoints to list RDP/SQL Server connections.
+ Add the ability to optionally specifying what kind of verb should be used when creating a connection to a Windows agent.
+ Add `RDP` and `SQLServer` to `VerbType`
