### PR TITLE
Add name field for editing environments after creation

### DIFF
--- a/.changes/unreleased/ENHANCEMENTS-20230725-142941.yaml
+++ b/.changes/unreleased/ENHANCEMENTS-20230725-142941.yaml
@@ -1,6 +1,6 @@
 kind: ENHANCEMENTS
-body: 'bastionzero/service: `Name` is added as an accepted field for modifying existing environments.
+body: 'environments: `Name` is added as an accepted field for modifying existing environments.
   New environment name must still be unique.'
 time: 2023-07-25T14:29:41.345311-04:00
 custom:
-  Issues: CWC-2702
+  Issues: '26'

--- a/.changes/unreleased/ENHANCEMENTS-20230725-142941.yaml
+++ b/.changes/unreleased/ENHANCEMENTS-20230725-142941.yaml
@@ -1,0 +1,6 @@
+kind: ENHANCEMENTS
+body: 'bastionzero/service: `Name` is added as an accepted field for modifying existing environments.
+  New environment name must still be unique.'
+time: 2023-07-25T14:29:41.345311-04:00
+custom:
+  Issues: CWC-2702

--- a/bastionzero/service/environments/environments.go
+++ b/bastionzero/service/environments/environments.go
@@ -38,7 +38,7 @@ type CreateEnvironmentResponse struct {
 
 // ModifyEnvironmentRequest is used to modify an environment
 type ModifyEnvironmentRequest struct {
-	Name        *string `json:"name"`
+	Name        *string `json:"name,omitempty"`
 	Description *string `json:"description,omitempty"`
 	// OfflineCleanupTimeoutHours is the amount of time (in hours) to wait until
 	// offline targets are automatically removed by BastionZero.

--- a/bastionzero/service/environments/environments.go
+++ b/bastionzero/service/environments/environments.go
@@ -38,6 +38,7 @@ type CreateEnvironmentResponse struct {
 
 // ModifyEnvironmentRequest is used to modify an environment
 type ModifyEnvironmentRequest struct {
+	Name        *string `json:"name"`
 	Description *string `json:"description,omitempty"`
 	// OfflineCleanupTimeoutHours is the amount of time (in hours) to wait until
 	// offline targets are automatically removed by BastionZero.


### PR DESCRIPTION
Related to the Connection Node Failover backend PR -> https://github.com/bastionzero/webshell-backend/pull/1636
Adds `Name` to the modify environment request struct, which allows changing the name after creation as long as the new name is still unique.