### PR TITLE
Add `update-config` endpoint for bzero targets

### DIFF
--- a/.changes/unreleased/FEATURES-20230912-123837.yaml
+++ b/.changes/unreleased/FEATURES-20230912-123837.yaml
@@ -1,5 +1,5 @@
 kind: FEATURES
-body: Add new endpoint that updates an agent's config for supported keys
+body: targets/bzero: Add new endpoint that updates an agent's config for supported keys
 time: 2023-09-12T12:38:37.196317-04:00
 custom:
   Issues: "34"

--- a/.changes/unreleased/FEATURES-20230912-123837.yaml
+++ b/.changes/unreleased/FEATURES-20230912-123837.yaml
@@ -2,4 +2,4 @@ kind: FEATURES
 body: Add new endpoint that updates an agent's config for supported keys
 time: 2023-09-12T12:38:37.196317-04:00
 custom:
-  Issues: "33"
+  Issues: "34"

--- a/.changes/unreleased/FEATURES-20230912-123837.yaml
+++ b/.changes/unreleased/FEATURES-20230912-123837.yaml
@@ -1,0 +1,5 @@
+kind: FEATURES
+body: Add new endpoint that updates an agent's config for supported keys
+time: 2023-09-12T12:38:37.196317-04:00
+custom:
+  Issues: "33"

--- a/bastionzero/service/targets/bzero.go
+++ b/bastionzero/service/targets/bzero.go
@@ -38,6 +38,16 @@ type RequestBzeroAgentLogsRequest struct {
 	UploadLogsRequestId string `json:"uploadLogsRequestId"`
 }
 
+// UpdateAgentConfigRequest is used to update the Bzero agent config
+type UpdateAgentConfigRequest struct {
+	TargetID        string `json:"targetId,omitempty"`
+	TargetName      string `json:"targetName,omitempty"`
+	EnvironmentID   string `json:"envId,omitempty"`
+	EnvironmentName string `json:"envName,omitempty"`
+	Key             string `json:"key"`
+	NewValue        string `json:"newValue"`
+}
+
 // BzeroTarget is a target running the Bzero agent
 type BzeroTarget struct {
 	Target
@@ -145,6 +155,24 @@ func (s *TargetsService) RestartBzeroTarget(ctx context.Context, request *Restar
 // BastionZero API docs: https://cloud.bastionzero.com/api/#post-/api/v2/targets/bzero/retrieve-logs
 func (s *TargetsService) RequestBzeroTargetLogs(ctx context.Context, request *RequestBzeroAgentLogsRequest) (*http.Response, error) {
 	u := bzeroBasePath + "/retrieve-logs"
+	req, err := s.Client.NewRequest(ctx, http.MethodPost, u, request)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.Client.Do(req, nil)
+	if err != nil {
+		return resp, err
+	}
+
+	return resp, nil
+}
+
+// UpdateAgentConfig requests that the Bzero agent's config is updated.
+//
+// BastionZero API docs: https://cloud.bastionzero.com/api/#post-/api/v2/targets/bzero/update-config
+func (s *TargetsService) UpdateAgentConfig(ctx context.Context, request *UpdateAgentConfigRequest) (*http.Response, error) {
+	u := bzeroBasePath + "/update-config"
 	req, err := s.Client.NewRequest(ctx, http.MethodPost, u, request)
 	if err != nil {
 		return nil, err

--- a/bastionzero/service/targets/bzero.go
+++ b/bastionzero/service/targets/bzero.go
@@ -45,7 +45,7 @@ type UpdateAgentConfigRequest struct {
 	EnvironmentID   string `json:"envId,omitempty"`
 	EnvironmentName string `json:"envName,omitempty"`
 	Key             string `json:"key"`
-	NewValue        string `json:"newValue"`
+	Value           string `json:"value"`
 }
 
 // BzeroTarget is a target running the Bzero agent


### PR DESCRIPTION
JIRA ticket: https://commonwealthcrypto.atlassian.net/browse/CWC-2718
Adds the `UpdateAgentConfigRequest` struct and `UpdateAgentConfig` function to `bzero.go`
Adds new changie entry

Backend PR: https://github.com/bastionzero/webshell-backend/pull/1660