### PR TITLE
Add `CloseConnection` + Fix `Kube` `ConnectionType` + Add other connection types

### DIFF
--- a/.changes/unreleased/BUG FIXES-20230927-012225.yaml
+++ b/.changes/unreleased/BUG FIXES-20230927-012225.yaml
@@ -1,0 +1,6 @@
+kind: BUG FIXES
+body: 'connections/connectiontype: Fix mapping of `Kube` to match expected value; it
+  now maps to `Kubernetes`'
+time: 2023-09-27T01:22:25.375712-04:00
+custom:
+  Issues: "37"

--- a/.changes/unreleased/ENHANCEMENTS-20230927-012111.yaml
+++ b/.changes/unreleased/ENHANCEMENTS-20230927-012111.yaml
@@ -1,0 +1,5 @@
+kind: ENHANCEMENTS
+body: 'connections/connectiontype: Add `Rdp` and `SqlServer`'
+time: 2023-09-27T01:21:11.494876-04:00
+custom:
+  Issues: "37"

--- a/.changes/unreleased/FEATURES-20230927-012000.yaml
+++ b/.changes/unreleased/FEATURES-20230927-012000.yaml
@@ -1,0 +1,5 @@
+kind: FEATURES
+body: 'connections: Add endpoint to close a single connection'
+time: 2023-09-27T01:20:00.79065-04:00
+custom:
+  Issues: "37"

--- a/bastionzero/service/connections/connections.go
+++ b/bastionzero/service/connections/connections.go
@@ -2,6 +2,7 @@ package connections
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/bastionzero/bastionzero-sdk-go/bastionzero/service/connections/connectionstate"
@@ -169,4 +170,22 @@ func (s *ConnectionsService) CreateUniversalSshConnection(ctx context.Context, r
 	}
 
 	return createConnResponse, resp, nil
+}
+
+// CloseConnection closes a connection.
+//
+// BastionZero API docs: https://cloud.bastionzero.com/api/#patch-/api/v2/connections/-id-/close
+func (s *ConnectionsService) CloseConnection(ctx context.Context, connectionID string) (*http.Response, error) {
+	u := connectionsBasePath + fmt.Sprintf("/%s/close", connectionID)
+	req, err := s.Client.NewRequest(ctx, http.MethodPatch, u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.Client.Do(req, nil)
+	if err != nil {
+		return resp, err
+	}
+
+	return resp, nil
 }

--- a/bastionzero/service/connections/connectiontype/connectiontype.go
+++ b/bastionzero/service/connections/connectiontype/connectiontype.go
@@ -10,12 +10,16 @@ const (
 	Shell ConnectionType = "Shell"
 	// Dynamic represents a connection to a dynamic access target (DAT)
 	Dynamic ConnectionType = "Dynamic"
-	// Kube represents a Kube connection
-	Kube ConnectionType = "Kube"
+	// Kube represents a Kubernetes connection
+	Kube ConnectionType = "Kubernetes"
 	// Web represents a Web connection
 	Web ConnectionType = "Web"
 	// Db represents a Db connection
 	Db ConnectionType = "Db"
-	// Ssh represents a ssh connection
+	// Ssh represents an ssh connection
 	Ssh ConnectionType = "Ssh"
+	// Rdp represents a RDP connection
+	Rdp ConnectionType = "Rdp"
+	// SqlServer represents a SQLServer connection
+	SqlServer ConnectionType = "SqlServer"
 )

--- a/bastionzero/service/connections/connectiontype/generated.go
+++ b/bastionzero/service/connections/connectiontype/generated.go
@@ -3,12 +3,14 @@ package connectiontype
 
 // validConnectionTypeValues contains a map of all valid ConnectionType values for easy lookup
 var validConnectionTypeValues = map[ConnectionType]struct{}{
-	Shell:   {},
-	Dynamic: {},
-	Kube:    {},
-	Web:     {},
-	Db:      {},
-	Ssh:     {},
+	Shell:     {},
+	Dynamic:   {},
+	Kube:      {},
+	Web:       {},
+	Db:        {},
+	Ssh:       {},
+	Rdp:       {},
+	SqlServer: {},
 }
 
 // Valid validates if a value is a valid ConnectionType
@@ -26,5 +28,7 @@ func ConnectionTypeValues() []ConnectionType {
 		Web,
 		Db,
 		Ssh,
+		Rdp,
+		SqlServer,
 	}
 }


### PR DESCRIPTION
- Adds support for closing a connection: `ConnectionsService.CloseConnection()`
- Fixes `Kube` connection type to match backend's API connection type. This is a backwards compatible fix because I only changed what the type name maps to `string`-wise (`Kube` --> `Kubernetes`, but type is still called `Kube`). When we want to batch a bunch of breaking changes in a single breaking release we can rename the type to `Kubernetes` to be consistent. Also, the type was not used at all in the SDK (although technically public, so that's why I'm still keeping it backwards compatible)
- Adds `Rdp` and `SqlServer` to `ConnectionType`