### PR TITLE
Feat/Environments as proxies

### DIFF
--- a/.changes/unreleased/FEATURES-20231031-160804.yaml
+++ b/.changes/unreleased/FEATURES-20231031-160804.yaml
@@ -1,6 +1,5 @@
-kind: FEATURES
-body: 'targets: Add ProxyEnvironmentId for create and edit requests for db and web
-  targets'
+kind: ENHANCEMENTS
+body: 'targets, targets_disambiguated: Add `ProxyEnvironmentId` for create/edit requests and get/list responses for db and web targets; when creating/editing these targets, one of either `ProxyEnvironmentId` or `ProxyTargetId`'
 time: 2023-10-31T16:08:04.458333-04:00
 custom:
   Issues: "42"

--- a/.changes/unreleased/FEATURES-20231031-160804.yaml
+++ b/.changes/unreleased/FEATURES-20231031-160804.yaml
@@ -1,0 +1,6 @@
+kind: FEATURES
+body: 'targets: Add ProxyEnvironmentId for create and edit requests for db and web
+  targets'
+time: 2023-10-31T16:08:04.458333-04:00
+custom:
+  Issues: "42"

--- a/.changes/unreleased/FEATURES-20231031-160804.yaml
+++ b/.changes/unreleased/FEATURES-20231031-160804.yaml
@@ -1,5 +1,5 @@
 kind: ENHANCEMENTS
-body: 'targets, targets_disambiguated: Add `ProxyEnvironmentId` for create/edit requests and get/list responses for db and web targets; when creating/editing these targets, one of either `ProxyEnvironmentId` or `ProxyTargetId`'
+body: 'targets, targets_disambiguated: Add `ProxyEnvironmentId` for create/edit requests and get/list responses for db and web targets; when creating/editing these targets, one of either `ProxyEnvironmentId` or `ProxyTargetId` is required'
 time: 2023-10-31T16:08:04.458333-04:00
 custom:
   Issues: "42"

--- a/bastionzero/service/targets/database.go
+++ b/bastionzero/service/targets/database.go
@@ -51,7 +51,7 @@ type CreateDatabaseTargetResponse struct {
 type ModifyDatabaseTargetRequest struct {
 	TargetName         *string `json:"targetName,omitempty"`
 	ProxyTargetID      *string `json:"proxyTargetId,omitempty"`
-	ProxyEnvironmentID string  `json:"proxyEnvironmentId,omitempty"`
+	ProxyEnvironmentID *string `json:"proxyEnvironmentId,omitempty"`
 	RemoteHost         *string `json:"remoteHost,omitempty"`
 	RemotePort         *Port   `json:"remotePort,omitempty"`
 	LocalPort          *Port   `json:"localPort,omitempty"`

--- a/bastionzero/service/targets/database.go
+++ b/bastionzero/service/targets/database.go
@@ -18,9 +18,10 @@ const (
 
 // CreateDatabaseTargetRequest is used to create a new Database target
 type CreateDatabaseTargetRequest struct {
-	TargetName    string `json:"targetName"`
-	ProxyTargetID string `json:"proxyTargetId"`
-	RemoteHost    string `json:"remoteHost"`
+	TargetName         string `json:"targetName"`
+	ProxyTargetID      string `json:"proxyTargetId,omitempty"`
+	ProxyEnvironmentID string `json:"proxyEnvironmentId,omitempty"`
+	RemoteHost         string `json:"remoteHost"`
 	// TODO: To match REST API, change to: RemotePort *Port  `json:"remotePort,omitempty"`
 	// and update the comment below in a batched breaking changes release
 
@@ -48,12 +49,13 @@ type CreateDatabaseTargetResponse struct {
 
 // ModifyDatabaseTargetRequest is used to modify a Database target
 type ModifyDatabaseTargetRequest struct {
-	TargetName    *string `json:"targetName,omitempty"`
-	ProxyTargetID *string `json:"proxyTargetId,omitempty"`
-	RemoteHost    *string `json:"remoteHost,omitempty"`
-	RemotePort    *Port   `json:"remotePort,omitempty"`
-	LocalPort     *Port   `json:"localPort,omitempty"`
-	LocalHost     *string `json:"localHost,omitempty"`
+	TargetName         *string `json:"targetName,omitempty"`
+	ProxyTargetID      *string `json:"proxyTargetId,omitempty"`
+	ProxyEnvironmentID string  `json:"proxyEnvironmentId,omitempty"`
+	RemoteHost         *string `json:"remoteHost,omitempty"`
+	RemotePort         *Port   `json:"remotePort,omitempty"`
+	LocalPort          *Port   `json:"localPort,omitempty"`
+	LocalHost          *string `json:"localHost,omitempty"`
 	// Deprecated: IsSplitCert exists for historical compatibility and should not be used.
 	// Set AuthenticationType in DatabaseAuthenticationConfig appropriately instead.
 	IsSplitCert *bool `json:"splitCert,omitempty"`

--- a/bastionzero/service/targets/database.go
+++ b/bastionzero/service/targets/database.go
@@ -17,6 +17,7 @@ const (
 )
 
 // CreateDatabaseTargetRequest is used to create a new Database target
+// One of either ProxyTargetID or ProxyEnvironmentID must be specified
 type CreateDatabaseTargetRequest struct {
 	TargetName         string `json:"targetName"`
 	ProxyTargetID      string `json:"proxyTargetId,omitempty"`

--- a/bastionzero/service/targets/targets.go
+++ b/bastionzero/service/targets/targets.go
@@ -77,6 +77,8 @@ type VirtualTargetInterface interface {
 
 	// GetProxyTargetID returns the virtual target's proxy target's ID.
 	GetProxyTargetID() string
+	// GetProxyEnvironmentID returns the virtual target's proxy environment's ID.
+	GetProxyEnvironmentID() string
 	// GetRemoteHost returns the virtual target's remote host.
 	GetRemoteHost() string
 	// GetRemotePort returns the virtual target's remote port.
@@ -125,7 +127,12 @@ type VirtualTarget struct {
 
 	// ProxyTargetID is the ID of the target that proxies connections made to
 	// this virtual target
+	// One of either ProxyTargetID or ProxyEnvironmentID must be specified when creating a target
 	ProxyTargetID string `json:"proxyTargetId"`
+	// ProxyEnvironmentID is the ID of the environemnt that proxies connections made to
+	// this virtual target by assigning a base target from within that environment.
+	// One of either ProxyTargetID or ProxyEnvironmentID must be specified when creating a target
+	ProxyEnvironmentID string `json:"proxyEnvironmentId"`
 	// RemoteHost is the IP address of the remote server that is connected to
 	// when a connection is made to this virtual target
 	RemoteHost string `json:"remoteHost"`
@@ -139,7 +146,8 @@ type VirtualTarget struct {
 	LocalHost string `json:"localHost"`
 }
 
-func (t *VirtualTarget) GetProxyTargetID() string { return t.ProxyTargetID }
-func (t *VirtualTarget) GetRemoteHost() string    { return t.RemoteHost }
-func (t *VirtualTarget) GetRemotePort() Port      { return t.RemotePort }
-func (t *VirtualTarget) GetLocalPort() Port       { return t.LocalPort }
+func (t *VirtualTarget) GetProxyTargetID() string      { return t.ProxyTargetID }
+func (t *VirtualTarget) GetProxyEnvironmentID() string { return t.ProxyEnvironmentID }
+func (t *VirtualTarget) GetRemoteHost() string         { return t.RemoteHost }
+func (t *VirtualTarget) GetRemotePort() Port           { return t.RemotePort }
+func (t *VirtualTarget) GetLocalPort() Port            { return t.LocalPort }

--- a/bastionzero/service/targets/targets.go
+++ b/bastionzero/service/targets/targets.go
@@ -129,7 +129,7 @@ type VirtualTarget struct {
 	// this virtual target
 	// One of either ProxyTargetID or ProxyEnvironmentID must be specified when creating a target
 	ProxyTargetID string `json:"proxyTargetId"`
-	// ProxyEnvironmentID is the ID of the environemnt that proxies connections made to
+	// ProxyEnvironmentID is the ID of the environment that proxies connections made to
 	// this virtual target by assigning a base target from within that environment.
 	// One of either ProxyTargetID or ProxyEnvironmentID must be specified when creating a target
 	ProxyEnvironmentID string `json:"proxyEnvironmentId"`

--- a/bastionzero/service/targets/web.go
+++ b/bastionzero/service/targets/web.go
@@ -15,13 +15,14 @@ const (
 
 // CreateWebTargetRequest is used to create a new Web target
 type CreateWebTargetRequest struct {
-	TargetName      string `json:"targetName"`
-	RemotePort      Port   `json:"remotePort"`
-	ProxyTargetID   string `json:"proxyTargetId"`
-	LocalPort       *Port  `json:"localPort,omitempty"`
-	LocalHost       string `json:"localHost,omitempty"`
-	EnvironmentID   string `json:"environmentId,omitempty"`
-	EnvironmentName string `json:"environmentName,omitempty"`
+	TargetName         string `json:"targetName"`
+	RemotePort         Port   `json:"remotePort"`
+	ProxyTargetID      string `json:"proxyTargetId,omitempty"`
+	ProxyEnvironmentID string `json:"proxyEnvironmentId,omitempty"`
+	LocalPort          *Port  `json:"localPort,omitempty"`
+	LocalHost          string `json:"localHost,omitempty"`
+	EnvironmentID      string `json:"environmentId,omitempty"`
+	EnvironmentName    string `json:"environmentName,omitempty"`
 	// RemoteHost is the URL of the web server. It must start with the scheme
 	// (http:// or https://) that the host is expecting.
 	RemoteHost string `json:"remoteHost"`
@@ -38,13 +39,14 @@ type CreateWebTargetResponse struct {
 
 // ModifyWebTargetRequest is used to modify a Web target
 type ModifyWebTargetRequest struct {
-	TargetName    *string `json:"targetName,omitempty"`
-	ProxyTargetID *string `json:"proxyTargetId,omitempty"`
-	RemoteHost    *string `json:"remoteHost,omitempty"`
-	RemotePort    *Port   `json:"remotePort,omitempty"`
-	LocalPort     *Port   `json:"localPort,omitempty"`
-	LocalHost     *string `json:"localHost,omitempty"`
-	EnvironmentID *string `json:"environmentId,omitempty"`
+	TargetName         *string `json:"targetName,omitempty"`
+	ProxyTargetID      *string `json:"proxyTargetId,omitempty"`
+	ProxyEnvironmentID string  `json:"proxyEnvironmentId,omitempty"`
+	RemoteHost         *string `json:"remoteHost,omitempty"`
+	RemotePort         *Port   `json:"remotePort,omitempty"`
+	LocalPort          *Port   `json:"localPort,omitempty"`
+	LocalHost          *string `json:"localHost,omitempty"`
+	EnvironmentID      *string `json:"environmentId,omitempty"`
 }
 
 // WebTarget is a virtual target that provides HTTP(S) access to a remote web

--- a/bastionzero/service/targets/web.go
+++ b/bastionzero/service/targets/web.go
@@ -41,7 +41,7 @@ type CreateWebTargetResponse struct {
 type ModifyWebTargetRequest struct {
 	TargetName         *string `json:"targetName,omitempty"`
 	ProxyTargetID      *string `json:"proxyTargetId,omitempty"`
-	ProxyEnvironmentID string  `json:"proxyEnvironmentId,omitempty"`
+	ProxyEnvironmentID *string `json:"proxyEnvironmentId,omitempty"`
 	RemoteHost         *string `json:"remoteHost,omitempty"`
 	RemotePort         *Port   `json:"remotePort,omitempty"`
 	LocalPort          *Port   `json:"localPort,omitempty"`

--- a/bastionzero/service/targets/web.go
+++ b/bastionzero/service/targets/web.go
@@ -14,6 +14,7 @@ const (
 )
 
 // CreateWebTargetRequest is used to create a new Web target
+// One of either ProxyTargetID or ProxyEnvironmentID must be specified
 type CreateWebTargetRequest struct {
 	TargetName         string `json:"targetName"`
 	RemotePort         Port   `json:"remotePort"`

--- a/bastionzero/service/targets_disambiguated/database_target.go
+++ b/bastionzero/service/targets_disambiguated/database_target.go
@@ -11,6 +11,7 @@ type DatabaseTarget struct {
 
 	ProxyAgentId                 string                                    `json:"proxyAgentId"`
 	ProxyAgentName               string                                    `json:"proxyAgentName"`
+	ProxyEnvironmentId           string                                    `json:"proxyEnvironmentId"`
 	RemoteHost                   string                                    `json:"remoteHost"`
 	RemotePort                   Port                                      `json:"remotePort"`
 	LocalHost                    string                                    `json:"localHost"`

--- a/bastionzero/service/targets_disambiguated/web_target.go
+++ b/bastionzero/service/targets_disambiguated/web_target.go
@@ -7,11 +7,12 @@ import (
 type WebTarget struct {
 	Target
 
-	ProxyAgentId   string                      `json:"proxyAgentId"`
-	ProxyAgentName string                      `json:"proxyAgentName"`
-	RemoteHost     string                      `json:"remoteHost"`
-	RemotePort     Port                        `json:"remotePort"`
-	LocalHost      string                      `json:"localHost"`
-	LocalPort      *Port                       `json:"localPort"`
-	Connections    []connections.WebConnection `json:"connections"`
+	ProxyAgentId       string                      `json:"proxyAgentId"`
+	ProxyAgentName     string                      `json:"proxyAgentName"`
+	ProxyEnvironmentId string                      `json:"proxyEnvironmentId"`
+	RemoteHost         string                      `json:"remoteHost"`
+	RemotePort         Port                        `json:"remotePort"`
+	LocalHost          string                      `json:"localHost"`
+	LocalPort          *Port                       `json:"localPort"`
+	Connections        []connections.WebConnection `json:"connections"`
 }


### PR DESCRIPTION
Adds proxy environment id as an attribute to database and web targets. Proxy target id is not required now. Either or value needs to be specified 