### PR TITLE
Add link to open source software attestations in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,4 +90,5 @@ closely as we can for tagging releases of the package.
 ## License
 
 This library is distributed under the Apache License 2.0 license found in the
-[LICENSE](./LICENSE) file.
+[LICENSE](./LICENSE) file and includes [open source software](https://docs.bastionzero.com/docs/credits/go-sdk)
+under a variety of other licenses.


### PR DESCRIPTION
Adds link to open source software attestations (hosted on gitbooks docs page) in the `README.md`'s "License" section: https://github.com/bastionzero/bastionzero-sdk-go/blob/credits/README.md#license